### PR TITLE
Update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module grsync
+module github.com/zloylos/grsync
 
 go 1.13
 


### PR DESCRIPTION
Or otherwise, `go get -u github.com/zloylos/grsync` gives you this error:

```
go get: github.com/zloylos/grsync@v0.0.0-20200128213510-1ec26db922d6: parsing go.mod:
        module declares its path as: grsync
                but was required as: github.com/zloylos/grsync
```